### PR TITLE
Remember last date when ingesting to save time

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -23,7 +23,11 @@ with open("config.json", "r") as f:
     if "last-scanned-folder-date" not in data:
         data["last-scanned-folder-date"] = LAST_SCANNED_FOLDER_DATE_DEFAULT_CONFIG_VALUE
 
-    LAST_SCANNED_FOLDER_DATE = convert_date_string_to_unix(data["last-scanned-folder-date"])
+    try:
+        LAST_SCANNED_FOLDER_DATE = convert_date_string_to_unix(data["last-scanned-folder-date"])
+    except:
+        print("Failed to read \"last-scanned-folder-date\" from config.json, make sure it's a string in YYYY-MM-DD format, for example 2023-12-31")
+        exit()
 
 def update_config():
     with open("config.json", "w") as f:


### PR DESCRIPTION
This PR's purpose is to remember the last ingested file's timestamp so that next ingest will start from there and ignore any files before that time.

This is realized by saving the timestamp in human readable YYYY-MM-DD format (for easier editing by a user) in the config.json (backwards compatible, will create new timestamp if didn't exist before).
Files will be read for dates after and including the last saved date.

What this achieves is that after you generate, and have ran the website and atleast one Refresh (OS directory crawl for the first time is delayed), consecutive refreshes are almost instantly updating the UI, just have to re-query it again.

If the user deletes the database file to regenerate, the date will be wiped automatically aswell